### PR TITLE
go routine for edge RunProc

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -83,7 +83,7 @@ func main() {
 	//config.XMicroEdgeServiceTransport
 	//config.XMicroEdgeServiceAddr
 
-	edge.RunProc()
+	go edge.RunProc()
 
 	// Run service
 	if err := service.Run(); err != nil {

--- a/service.go
+++ b/service.go
@@ -2,6 +2,7 @@ package edge
 
 import (
 	"fmt"
+
 	esrv "github.com/micro-community/x-edge/end/server"
 	"github.com/micro/go-micro"
 	"github.com/micro/go-micro/server"
@@ -35,7 +36,7 @@ func RunProc() {
 		),
 	)
 
-	service.Init()
+	//service.Init()
 
 	//register server message router
 	router.RegisterProtocolHandler(svr, new(router.ProtocolServer))


### PR DESCRIPTION
modify the go routine for edge RunProc,  cancel the function of service.init in  edge