### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
      steps:
        - uses: actions/checkout@v2
          name: Check out repository
-       - uses: elgohr/Publish-Docker-Github-Action@2.12
+       - uses: elgohr/Publish-Docker-Github-Action@v5
          name: Build and Push Docker Image
          with:
            name: micro-community/x-edge


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore